### PR TITLE
Test managed resource readiness, and external name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # conformance
 
-An experimental [Sonobuoy] plugin to assess [Crossplane] conformance. To try it,
-first download the `sonobuoy` CLI, then:
+A [Sonobuoy] plugin to assess [Crossplane] conformance. To try it, first
+download the `sonobuoy` CLI, then:
 
 ```console
 # To determine whether a Crossplane distribution is conformant. The distribution
@@ -15,6 +15,10 @@ sonobuoy results $(sonobuoy retrieve) -m dump
 sonobuoy run --wait --plugin https://raw.githubusercontent.com/crossplane/conformance/main/plugin-provider.yaml
 sonobuoy results $(sonobuoy retrieve) -m dump
 ```
+
+Note that the provider conformance tests require some advanced setup. The test
+requires that at least one of each kind of managed resource exists and is ready
+(in the status condition sense).
 
 [sonobuoy]: https://sonobuoy.io/
 [crossplane]: https://crossplane.io/

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -179,12 +179,12 @@ func TestPackage(t *testing.T) {
 			case "ProviderConfigUsage":
 				totalPCUs += len(l.Items)
 			default:
-				if len(l.Items) != 1 {
-					t.Errorf("Exactly one %q managed resource must be manually created in advance. Found %d", crd.GetName(), len(l.Items))
+				if len(l.Items) == 0 {
+					t.Errorf("At least one %q managed resource must be manually created in advance.", crd.GetName())
 					continue
 				}
 				t.Run(crd.Spec.Names.Kind, SubtestForManagedResource(&l.Items[0]))
-				totalMRs++
+				totalMRs += len(l.Items)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Nic Cope <negz@rk0n.org>

<!--
Thank you for helping to improve conformance!

Please read through https://git.io/fj2m9 if this is your first time opening a
conformance pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open conformance issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Advances https://github.com/crossplane/conformance/issues/10

This PR takes provider conformance a step further by smoke testing that all managed resources defined by a provider can become ready, and populate their `crossplane.io/external-name` annotation. We rely on the person running the conformance test to manually create one of each kind of managed resource before running the test. I can't think of a great way to avoid this given that the conformance test logic can't know the schema, credentials, etc required to spin up and down managed resources.

I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've created a simple resource (a GCS bucket) and confirmed it passes the test.