### PR TITLE
Replace negz/provider-nop with crossplane/provider-nop

### DIFF
--- a/crossplane/apiextensions_test.go
+++ b/crossplane/apiextensions_test.go
@@ -453,13 +453,11 @@ func TestCompositeResource(t *testing.T) {
 		t.Fatalf("Create client: %v", err)
 	}
 
-	// TODO(negz): Use the other provider-nop from contrib once it's ready.
-	// https://github.com/crossplane-contrib/provider-nop
 	prv := &pkgv1.Provider{
 		ObjectMeta: metav1.ObjectMeta{Name: internal.SuiteName},
 		Spec: pkgv1.ProviderSpec{
 			PackageSpec: pkgv1.PackageSpec{
-				Package:                     "negz/provider-nop:v0.1.0",
+				Package:                     "crossplane/provider-nop:main",
 				IgnoreCrossplaneConstraints: pointer.BoolPtr(true),
 			},
 		},
@@ -686,6 +684,20 @@ func TestCompositeResource(t *testing.T) {
 					"apiVersion": "nop.crossplane.io/v1alpha1",
 					"kind": "NopResource",
 					"spec": {
+						"forProvider": {
+							"conditionAfter": [
+							   {
+								  "conditionType": "Ready",
+								  "conditionStatus": "True",
+								  "time": "0s"
+							   },
+							   {
+								  "conditionType": "Synced",
+								  "conditionStatus": "True",
+								  "time": "0s"
+							   }
+							]
+						 },
 						"writeConnectionSecretToRef": {
 							"namespace": "%s"
 						}

--- a/crossplane/configuration_test.go
+++ b/crossplane/configuration_test.go
@@ -54,8 +54,7 @@ func TestConfiguration(t *testing.T) {
 		},
 	}
 
-	// The crossplane-conformance provider depends on negz/provider-nop.
-	prv := &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "negz-provider-nop"}}
+	prv := &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "crossplane-provider-nop"}}
 
 	if err := kube.Create(ctx, cfg); err != nil {
 		t.Fatalf("Create configuration %q: %v", cfg.GetName(), err)

--- a/crossplane/provider_test.go
+++ b/crossplane/provider_test.go
@@ -42,13 +42,11 @@ func TestProvider(t *testing.T) {
 		t.Fatalf("Create client: %v", err)
 	}
 
-	// TODO(negz): Use the other provider-nop from contrib once it's ready.
-	// https://github.com/crossplane-contrib/provider-nop
 	prv := &pkgv1.Provider{
 		ObjectMeta: metav1.ObjectMeta{Name: internal.SuiteName},
 		Spec: pkgv1.ProviderSpec{
 			PackageSpec: pkgv1.PackageSpec{
-				Package:                     "negz/provider-nop:v0.1.0",
+				Package:                     "crossplane/provider-nop:main",
 				IgnoreCrossplaneConstraints: pointer.BoolPtr(true),
 			},
 		},

--- a/testdata/configuration/crossplane.yaml
+++ b/testdata/configuration/crossplane.yaml
@@ -8,5 +8,5 @@ spec:
   crossplane:
     version: ">=v1.1.0"
   dependsOn:
-    - provider: negz/provider-nop
-      version: "v0.1.0"
+    - provider: crossplane/provider-nop
+      version: "main"


### PR DESCRIPTION
Signed-off-by: Rahul Grover <rahulgrover99@gmail.com>

<!--
Thank you for helping to improve conformance!

Please read through https://git.io/fj2m9 if this is your first time opening a
conformance pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Since [provider-nop](https://github.com/crossplane-contrib/provider-nop) is ready to use, it might be a good idea to use the same for conformance tests. I have replaced occurrences of `negz/provider-nop` with `crossplane/provider-nop` and added essential spec required for the same. 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open conformance issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've run the test on a local kind cluster running Crossplane 1.2. All the tests pass successfully except `TestConfiguration`. That might require updating the configuration image being used for the test.

[contribution process]: https://git.io/fj2m9
