### PR TITLE
Accomodate providers with default deletion policies and provider configs

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -368,10 +368,6 @@ func SubtestForManagedResourceCRD(crd *kextv1.CustomResourceDefinition) func(t *
 								{Raw: []byte(`"Delete"`)},
 							},
 						},
-						// TODO(negz): Ensure that 'name' defaults to 'default'
-						// once we expect providers to be built against
-						// crossplane-runtime v0.14+, which will includ3
-						// https://github.com/crossplane/crossplane-runtime/pull/255
 						"providerConfigRef": {
 							Type:       "object",
 							Required:   []string{"name"},
@@ -418,6 +414,14 @@ func SubtestForManagedResourceCRD(crd *kextv1.CustomResourceDefinition) func(t *
 			// spec fields we're concerned with are, but fields like 'forProvider'
 			// often are.
 			internal.IgnoreFieldsOfMapKey("spec", "Required"),
+
+			// TODO(negz): Verify that provider config and deletion
+			// policy defaulting is in place once providers have had
+			// enough time to update to runtime v0.14 (which is not
+			// yet released at the time of writing).
+			// https://github.com/crossplane/crossplane-runtime/pull/255
+			internal.IgnoreFieldsOfMapKey("providerConfigRef", "Default"),
+			internal.IgnoreFieldsOfMapKey("deletionPolicy", "Default"),
 
 			// We're only concerned with the spec and status fields that we expect
 			// all managed resources to include.


### PR DESCRIPTION
<!--
Thank you for helping to improve conformance!

Please read through https://git.io/fj2m9 if this is your first time opening a
conformance pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open conformance issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The defaulting of these fields will be introduced in crossplane-runtime v0.14 per https://github.com/crossplane/crossplane-runtime/pull/255. We'd like to support a transition period during which a provider may either specify the default or not. Unfortunately it's not easy to use cmp to test for "must be unset or value X" so I've just ignored the field for the time being

I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've run `cd provider && go test .` against https://github.com/crossplane/provider-aws/commit/84acbf60bd68f2f7527c36dc3d23e955261bd932 (which is using a pre-release of runtime-0.14) and verified that the conformance tests tolerate the presence of the default fields.