### PR TITLE
build: add img.promote target

### DIFF
--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -39,3 +39,8 @@ img.build.shared:
 		--platform linux/$(ARCH) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
+
+img.promote:
+	@$(INFO) docker promote $(FROM_IMAGE) to $(TO_IMAGE)
+	@docker buildx imagetools create -t $(TO_IMAGE) $(FROM_IMAGE)
+	@$(OK) docker promote $(FROM_IMAGE) to $(TO_IMAGE)


### PR DESCRIPTION
### Description of your changes

This PR addresses the publish-artifacts failure in https://github.com/crossplane/conformance/actions/runs/17748244007/job/50438010383:
```
make[2]: *** No rule to make target 'img.promote'.  Stop.
```

We simply follow the pattern used in the last c/c release that still used make: https://github.com/crossplane/crossplane/blob/release-1.16/cluster/images/crossplane/Makefile#L34-L37

I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have tested the build, publish, and now also promote path that [ci.yml](https://github.com/crossplane/conformance/blob/main/.github/workflows/ci.yml#L267-L274) uses by first updating `REGISTRY_ORGS ?= docker.io/jbw976` to push to my personal account, then running:

```
# build and publish, as before in https://github.com/crossplane/conformance/pull/32
❯ make -j2 build.all
❯ make -j2 publish BRANCH_NAME=main

# now actually exercise promote
❯ make -j2 promote BRANCH_NAME=main CHANNEL=master
09:19:15 [ .. ] docker promote docker.io/jbw976/conformance:v2.0.0-cf.1.rc.0.2.gb12f7b0-dirty to docker.io/jbw976/conformance:master
[+] Building 1.8s (1/1) FINISHED
 => [internal] pushing docker.io/jbw976/conformance:master                                                                                                                                                     1.8s
09:19:18 [ OK ] docker promote docker.io/jbw976/conformance:v2.0.0-cf.1.rc.0.2.gb12f7b0-dirty to docker.io/jbw976/conformance:master
```

This results in a successful publish/promote of `index.docker.io/jbw976/conformance:master`:
https://hub.docker.com/repository/docker/jbw976/conformance/tags/master/sha256-9a47abad459c4d88705d45be654741a23accf84da08dbeeda6aa3ff37f00032e

[contribution process]: https://git.io/fj2m9
