### PR TITLE
update conformance-testdata-configuration for v2

### DIFF
--- a/testdata/configuration/composition.yaml
+++ b/testdata/configuration/composition.yaml
@@ -9,21 +9,31 @@ spec:
   writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: test.crossplane.io/v1alpha1
-    kind: Conformance
-  resources:
-    - name: nop
-      base:
-        apiVersion: nop.crossplane.io/v1alpha1
-        kind: NopResource
-        spec:
-          forProvider: {}
-          writeConnectionSecretToRef:
-            namespace: crossplane-conformance
-            name: nop-example-resource
-      patches:
-        - fromFieldPath: spec.parameters.coolness
-          toFieldPath: metadata.annotations[nop.crossplane.io/coolness]
-          transforms:
-            - type: string
-              string:
-                fmt: "%d"
+    kind: ClusterConformance
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: crossplane-contrib-function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          - name: nop
+            base:
+              apiVersion: nop.crossplane.io/v1alpha1
+              kind: ClusterNopResource
+              spec:
+                forProvider: {}
+                writeConnectionSecretToRef:
+                  namespace: crossplane-conformance
+                  name: nop-example-resource
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.coolness
+                toFieldPath: metadata.annotations[nop.crossplane.io/coolness]
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%.0f"

--- a/testdata/configuration/crossplane.yaml
+++ b/testdata/configuration/crossplane.yaml
@@ -6,7 +6,9 @@ metadata:
     crossplane.io/test: crossplane-conformance
 spec:
   crossplane:
-    version: ">=v1.15.0"
+    version: ">=v2.0.0"
   dependsOn:
     - provider: xpkg.crossplane.io/crossplane-contrib/provider-nop
-      version: "v0.4.0"
+      version: "v0.5.0"
+    - function: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform
+      version: "v0.9.0"

--- a/testdata/configuration/definition.yaml
+++ b/testdata/configuration/definition.yaml
@@ -1,20 +1,16 @@
 ---
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: clusterconformances.test.crossplane.io
   labels:
     crossplane.io/test: crossplane-conformance
 spec:
+  scope: Cluster
   group: test.crossplane.io
   names:
     kind: ClusterConformance
     plural: clusterconformances
-  claimNames:
-    kind: Conformance
-    plural: conformances
-  connectionSecretKeys:
-    - test
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
### Description of your changes

This PR updates the contents of the `crossplane/conformance-testdata-configuration` test configuration package that is used in the `TestConfiguration` conformance test case:

- convert to function pipeline from native patch and transform
- use cluster scoped v2 XRD
- use latest provider-nop with ClusterNopResource
- add more tests and cleanup to verify new function dependencies succeed

This was missed in #31 because the `TestConfiguration` test was always failing due to no longer existing dependencies and we needed a build from main after #31 to then have a test package to run this test case on and realize it doesn't work 😂 

I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've built, pushed, and tested a test configuration package with my personal account: [`index.docker.io/jbw976/conformance-testdata-configuration:v2.0.0-cf.1-rc.0-20250917`](https://hub.docker.com/repository/docker/jbw976/conformance-testdata-configuration/tags/v2.0.0-cf.1-rc.0-20250917/sha256-408562dc416998d41f3bf413b0d742782e77aad90a34e22979d9b54bce7bb2e7)

```
❯ crossplane xpkg build -f testdata/configuration -o conformance.xpkg
❯ crossplane xpkg push -f conformance.xpkg index.docker.io/jbw976/conformance-testdata-configuration:v2.0.0-cf.1-rc.0-20250917

❯ go test -v -run TestConfiguration ./tests
=== RUN   TestConfiguration
    configuration_test.go:66: Created configuration "crossplane-conformance-configuration"
=== RUN   TestConfiguration/BecomesInstalledAndHealthy
    configuration_test.go:102: Testing that the configuration's Healthy and Installed status conditions become 'True'.
    configuration_test.go:109: Configuration "crossplane-conformance-configuration" is not yet Healthy
    configuration_test.go:109: Configuration "crossplane-conformance-configuration" is not yet Healthy
    configuration_test.go:118: Configuration "crossplane-conformance-configuration" is Healthy and Installed
=== RUN   TestConfiguration/RevisionBecomesHealthyAndDeploysObjects
    configuration_test.go:126: Testing that the configuration's revision's Healthy status conditions become 'True', and that it deploys its objects.
    configuration_test.go:140: Found revision "crossplane-conformance-configuration-408562dc4169" owned by configuration "crossplane-conformance-configuration"
    configuration_test.go:147: Revision "crossplane-conformance-configuration-408562dc4169" is RevisionHealthy
    configuration_test.go:168: Revision "crossplane-conformance-configuration-408562dc4169" created CompositeResourceDefinition "clusterconformances.test.crossplane.io"
    configuration_test.go:168: Revision "crossplane-conformance-configuration-408562dc4169" created Composition "crossplane-conformance"
=== RUN   TestConfiguration/DependenciesBecomesInstalledAndHealthy
    configuration_test.go:182: Testing that the configuration's dependencies' Healthy and Installed status conditions become 'True'.
    configuration_test.go:202: Provider "crossplane-contrib-provider-nop" is Healthy and Installed
    configuration_test.go:227: Function "crossplane-contrib-function-patch-and-transform" is Healthy and Installed
=== NAME  TestConfiguration
    configuration_test.go:91: Cleaning up configuration "crossplane-conformance-configuration".
    configuration_test.go:98: Deleted configuration "crossplane-conformance-configuration"
    configuration_test.go:80: Cleaning up function "crossplane-contrib-function-patch-and-transform".
    configuration_test.go:87: Deleted function "crossplane-contrib-function-patch-and-transform"
    configuration_test.go:69: Cleaning up provider "crossplane-contrib-provider-nop".
    configuration_test.go:76: Deleted provider "crossplane-contrib-provider-nop"
--- PASS: TestConfiguration (20.08s)
    --- PASS: TestConfiguration/BecomesInstalledAndHealthy (20.01s)
    --- PASS: TestConfiguration/RevisionBecomesHealthyAndDeploysObjects (0.01s)
    --- PASS: TestConfiguration/DependenciesBecomesInstalledAndHealthy (0.01s)
PASS
ok  	github.com/crossplane/conformance/tests	20.512s
```

[contribution process]: https://git.io/fj2m9
