### PR TITLE
build: enable multi-platform image publishing again

### DIFF
--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -3,8 +3,11 @@ WORKDIR /go
 RUN go get -u github.com/jstemmer/go-junit-report@v0.9.1
 
 FROM BASEIMAGE
+ARG TARGETOS
+ARG TARGETARCH
+
 COPY --from=0 /go/bin/go-junit-report /usr/local/bin/
-ADD conformance /usr/local/bin/
+COPY tests/${TARGETOS}_${TARGETARCH}/tests /usr/local/bin/conformance
 ADD run.sh /usr/local/bin/
 EXPOSE 8080
 USER 65532

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -32,11 +32,11 @@ endif
 
 img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cp $(OUTPUT_DIR)/tests/linux_$(ARCH)/tests $(IMAGE_TEMP_DIR)/conformance || $(FAIL)
+	@cp -r $(OUTPUT_DIR)/tests/ $(IMAGE_TEMP_DIR)/tests || $(FAIL)
 	@cp ../../../run.sh $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@docker buildx build $(BUILD_ARGS) \
-		--platform linux/$(ARCH) \
+		--platform $(IMAGE_PLATFORMS) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
 


### PR DESCRIPTION
### Description of your changes

This used to work with the old build submodule and image.mk, but I noticed we're no longer pushing multi-platform images now to https://hub.docker.com/repository/docker/crossplane/conformance/tags. This became obvious when running conformance tests with `crossplane/conformance:master` and seeing:
```
message: 'rpc error: code = NotFound desc = failed to pull and unpack image
          "docker.io/crossplane/conformance:master": no match for platform in manifest:
          not found'
        reason: ErrImagePull
```

With crossplane/build and imagelight.mk, we need to do the following with this PR:

- use `--platform $(IMAGE_PLATFORMS)` for docker buildx to build for all platforms
- copy all architectures of the compiled test binary to `IMAGE_TEMP_DIR`
- copy specific compiled conformance test binary in Dockerfile

I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have built/published the changes in this PR to `jbw976/conformance:v2.0.0-cf.1.rc.0.4.gafde435-dirty`. With the following changes:

* update `REGISTRY_ORGS ?= docker.io/jbw976`
* update plugin.yaml to `image: jbw976/conformance:v2.0.0-cf.1.rc.0.4.gafde435-dirty`

Run conformance test with `sonobuoy` and the published multi-platform image:
```
❯ make -j2 build.all
❯ make -j2 publish BRANCH_NAME=main
❯ sonobuoy run --wait --plugin ./plugin-crossplane.yaml
```

Successful conformance run!
```
❯ sonobuoy results $(sonobuoy retrieve) -m dump
name: crossplane-conformance
status: passed
meta:
  type: summary
items:
- name: report.xml
  status: passed
...
```

[contribution process]: https://git.io/fj2m9
