### PR TITLE
chore: pin plugin to v2.0.0-cf.1

### DIFF
--- a/plugin-crossplane.yaml
+++ b/plugin-crossplane.yaml
@@ -5,7 +5,7 @@ sonobuoy-config:
 spec:
   command: ["run.sh"]
   args:
-  image: crossplane/conformance:alpha
+  image: crossplane/conformance:v2.0.0-cf.1
   name: plugin
   resources: {}
   volumeMounts:


### PR DESCRIPTION
### Description of your changes

As part of the v2.0 conformance test suite release, we should pin the plugin-crossplane.yaml file to the release version of `v2.0.0-cf.1`

This PR is to the `release-2.0` branch, we don't want to do this in `main`.

I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

With this change in my local plugin-crossplane.yaml file, run:
```
❯ sonobuoy run --wait --plugin ./plugin-crossplane.yaml
```

And confirmed that the correct `v2.0.0-cf.1` version of conformance tests are running:
```
❯ kubectl -n sonobuoy -l sonobuoy-plugin=crossplane-conformance get pod
NAME                                                   READY   STATUS    RESTARTS   AGE
sonobuoy-crossplane-conformance-job-ef40071930c74256   2/2     Running   0          2m59s

❯ kubectl -n sonobuoy -l sonobuoy-plugin=crossplane-conformance get pod -o json | jq '.items[].spec.containers[0].image'
"crossplane/conformance:v2.0.0-cf.1"
```


[contribution process]: https://git.io/fj2m9
