### PR TITLE
docs: document lightweight release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ will be updated to match the Crossplane patch version. The `image` referenced by
 the [distribution] plugin in any particular release branch is always the
 authoritative conformance test for that major and minor version of Crossplane.
 
+## Releases
+
+To create a new release of this conformance suite for a new Crossplane version,
+we follow a lightweight process:
+
+* Create a release branch named `release-X.Y` using the Github UI
+* On the release branch
+  * Open/merge a PR to pin the release version in `plugin-crossplane.yaml`: [example PR]
+  * Run the Tag workflow with `vX.Y.0-cf.1`
+  * Run the CI workflow
+* On main branch
+  * Run the Tag workflow with `vX.Y+1.0-cf.1-rc.0`
+
 [sonobuoy]: https://sonobuoy.io/
 [crossplane]: https://crossplane.io/
 [distribution]: ./plugin-crossplane.yaml
+[example PR]: https://github.com/crossplane/conformance/pull/37


### PR DESCRIPTION
### Description of your changes

This PR documents a very lightweight release process for this conformance suite repo. This is basically so I don't forget this when v2.1 comes along 😉 

I have:

- [x] Read and followed conformance's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

We followed this process for https://github.com/crossplane/conformance/releases/tag/v2.0.0-cf.1.

[contribution process]: https://git.io/fj2m9
